### PR TITLE
Include privacy info for Cocoapods

### DIFF
--- a/MBProgressHUD.podspec
+++ b/MBProgressHUD.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '12.0'
   s.tvos.deployment_target = '12.0'
   s.source_files = '*.{h,m}'
+  s.resource_bundles = { 'MBProgressHUD_Privacy' => ['PrivacyInfo.xcprivacy'] }
   s.frameworks   = "CoreGraphics", "QuartzCore"
   s.requires_arc = true
 end


### PR DESCRIPTION
Added `resource_bundles` in Cocoapods to include the PrivacyInfo file to the bundle to support static linking.
Can refer to the related discussion from the below links.

https://github.com/SnapKit/SnapKit/pull/798
https://github.com/CocoaPods/CocoaPods/issues/10325#issuecomment-1718723762